### PR TITLE
fix: named volume attachment leading to rs re-election error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mongo:5
 # we take over the default & start mongo in replica set mode in a background task
 ENTRYPOINT mongod --port $MONGO_REPLICA_PORT --replSet rs0 --bind_ip_all & MONGOD_PID=$!; \
 # we prepare the replica set with a single node and prepare the root user config
-INIT_REPL_CMD="rs.initiate()"; \
+INIT_REPL_CMD="rs.initiate({'_id':'rs0', 'members':[{'_id':0, 'host':'localhost:$MONGO_REPLICA_PORT'}]})"; \
 # we wait for the replica set to be ready and then submit the commands just above
 until (mongo admin --port $MONGO_REPLICA_PORT --eval "$INIT_REPL_CMD"); do sleep 1; done; \
 # we are done but we keep the container by waiting on signals from the mongo task


### PR DESCRIPTION
When a named volume is assigned to the `/data/db`  dir, restarting the container built on the image leads to mongo not being able to re-elect the only PRIMARY.

See here:
![Screenshot 2023-12-11 at 6 55 44 PM](https://github.com/paulrostorp/mongo-db-replicaset-local-dev/assets/76215329/5d09b590-7f9d-4bbd-a9d1-35bc48855836)

Steps to reproduce:
1. Up the container via `docker-compose`, say via the example in README
2. Down it
3. Up it again
4. Interact with db
